### PR TITLE
Fix the first two FAT entries

### DIFF
--- a/lib/boot_sector.ml
+++ b/lib/boot_sector.ml
@@ -53,6 +53,8 @@ let sizeof = sizeof_t
 
 let _ = assert(sizeof = 512)
 
+let fat_id = 0xf8 (* fixed disk *)
+
 let marshal (buf: Cstruct.t) t =
   for i = 0 to Cstruct.len buf - 1 do
     Cstruct.set_uint8 buf i 0
@@ -64,7 +66,7 @@ let marshal (buf: Cstruct.t) t =
   set_t_number_of_fats buf t.number_of_fats;
   set_t_number_of_root_dir_entries buf t.number_of_root_dir_entries;
   set_t_total_sectors_small buf 0; (* means use total_sectors_large *)
-  set_t_media_descriptor buf 0xf8; (* fixed disk *)
+  set_t_media_descriptor buf fat_id;
   set_t_sectors_per_fat buf t.sectors_per_fat;
   set_t_sectors_per_track buf 0; (* not used *)
   set_t_heads buf 0; (* not used *)

--- a/lib/boot_sector.mli
+++ b/lib/boot_sector.mli
@@ -53,6 +53,10 @@ val detect_format: t -> Fat_format.t option
 (* Choose between FAT12, FAT16 and FAT32 using heuristic from:
    http://averstak.tripod.com/fatdox/bootsec.htm *)
 
+val fat_id: int
+(** The FAT ID which will be written in both the boot sector and
+    the 0th cluster of the FAT *)
+
 val sectors_of_fat: t -> int list
 
 val sectors_of_root_dir: t -> int list


### PR DESCRIPTION
The first entry (cluster 0) should have the 'FAT ID' in the lower
bits and the remaining bits of the entry (treated as 28-bits for FAT32)
set to 1.

The second entry should have all bits set (treated again as 28-bits
for FAT32).

Signed-off-by: David Scott dave.scott@eu.citrix.com
