### PR TITLE
Use buffered I/O by default in the command-line tool

### DIFF
--- a/fat/common.ml
+++ b/fat/common.ml
@@ -17,11 +17,12 @@
 type t = {
   debug: bool;
   verb: bool;
+  unbuffered: bool;
 }
 
 
-let make debug verb =
-  { debug; verb; }
+let make debug verb unbuffered =
+  { debug; verb; unbuffered; }
 
 let ( |> ) a b = b a
 

--- a/fat/main.ml
+++ b/fat/main.ml
@@ -39,8 +39,11 @@ let common_options_t =
   let verb =
     let doc = "Give verbose output." in
     let verbose = true, Arg.info ["v"; "verbose"] ~docs ~doc in 
-    Arg.(last & vflag_all [false] [verbose]) in 
-  Term.(pure Common.make $ debug $ verb)
+    Arg.(last & vflag_all [false] [verbose]) in
+  let unbuffered =
+    let doc = "Use unbuffered I/O (via O_DIRECT)." in
+    Arg.(value & flag & info ["unbuffered"] ~docs ~doc) in
+  Term.(pure Common.make $ debug $ verb $ unbuffered)
 
 let filename =
   let doc = Printf.sprintf "Path to the FAT image file." in


### PR DESCRIPTION
This speeds up activities like using 'fat add' to generate
the mirage-www files.img from 4:30s to 0:01.8s on my laptop
(with spinning disks)

Unbuffered I/O can still be used by adding '--unbuffered'

Signed-off-by: David Scott dave.scott@eu.citrix.com
