### PR TITLE
Return errors from size instead of raising Fs_error

### DIFF
--- a/lib/fs.ml
+++ b/lib/fs.ml
@@ -474,8 +474,9 @@ module Make (B: BLOCK_DEVICE
       )
 
   let size x path =
-    stat x path >>|= fun s ->
-    return (`Ok s.size)
+    stat x path >>= function
+    | `Ok s -> return (`Ok s.size)
+    | `Error _ as e -> return e
 
   let listdir x path =
     let path = Path.of_string path in


### PR DESCRIPTION
Without this, if the path doesn't exist then clients just get e.g.

```
Fatal error: exception Fs.Make(B)(M).Fs_error(_)
```

[ note: I'm assuming the change log gets updated from the Git log at release time, so not updating it manually ]
