### PR TITLE
Fix destroy function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.10.2 (trunk)
+* Fixed destroy, which previously would overwrite the entry with
+  uninitialised data, which might not set the deleted flag.
+
 0.10.1 (01-Feb-2013):
 * Use io-page.unix instead of io-page-unix.
 

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -511,13 +511,9 @@ let remove block filename =
     List.rev (List.fold_left (fun acc offset ->
         let b = Cstruct.sub block offset sizeof in
         let delta = Cstruct.create sizeof in
-        begin match unmarshal b with
-          | Lfn lfn ->
-            let lfn' = { lfn with lfn_deleted = true } in
-            marshal delta (Lfn lfn')
-          | Dos dos ->
-            let dos' = { dos with deleted = true } in
-            marshal b (Dos dos')
+        marshal delta begin match unmarshal b with
+          | Lfn lfn -> Lfn { lfn with lfn_deleted = true }
+          | Dos dos -> Dos { dos with deleted = true }
           | End -> assert false
         end;
         Update.from_cstruct (Int64.of_int offset) delta :: acc

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -329,6 +329,22 @@ let test_write ((filename: string), (offset, length)) () =
     return () in
   Lwt_main.run t
 
+let test_destroy () =
+  let t =
+    let open BlockError in
+    MemoryIO.connect "" >>= fun device ->
+    let open FsError in
+    MemFS.connect device >>= fun fs ->
+    MemFS.format fs 0x100000L >>= fun () ->
+    MemFS.create fs "/data" >>= fun () ->
+    MemFS.destroy fs "/data" >>= fun () ->
+    MemFS.listdir fs "/" >>= function
+    | [] -> return ()
+    | items ->
+        List.iter (Printf.printf "Item: %s\n") items;
+        assert_failure "Items present after destroy!" in
+  Lwt_main.run t
+
 let rec allpairs xs ys = match xs with
   | [] -> []
   | x :: xs -> List.map (fun y -> x, y) ys @ (allpairs xs ys)
@@ -349,5 +365,6 @@ let _ =
       "test_listdir" >:: test_listdir;
       "test_listdir_subdir" >:: test_listdir_subdir;
       "test_read" >:: test_read;
+      "test_destroy" >:: test_destroy;
     ] @ write_tests in
   run_test_tt_main suite


### PR DESCRIPTION
Fixes destroy, which previously would overwrite the entry with uninitialised data, which might not set the deleted flag.
