### PR TITLE
Only require get_buf from IO_PAGE

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -24,6 +24,7 @@ opam --version
 opam --git-version
 
 opam init 
+opam update
 opam install ${OPAM_PACKAGES}
 
 eval `opam config env`

--- a/lib/fs.ml
+++ b/lib/fs.ml
@@ -57,8 +57,7 @@ let string_of_filesystem_error = function
 
 module Make (B: BLOCK_DEVICE
   with type 'a io = 'a Lwt.t
-  and type page_aligned_buffer = Cstruct.t)(M: IO_PAGE
-  with type buf = Cstruct.t): (FS
+  and type page_aligned_buffer = Cstruct.t)(M: IO_PAGE): (FS
   with type id = B.t
   and type 'a io = 'a Lwt.t
   and type block_device_error = B.error
@@ -94,7 +93,7 @@ module Make (B: BLOCK_DEVICE
     | `Ok x -> f x
 
   let alloc bytes =
-    let pages = M.(to_cstruct (get ((bytes + 4095) / 4096))) in
+    let pages = M.get_buf ~n:((bytes + 4095) / 4096) () in
     Cstruct.sub pages 0 bytes
 
   (* TODO: this function performs extra data copies *)

--- a/lib/fs.mli
+++ b/lib/fs.mli
@@ -34,8 +34,7 @@ val string_of_filesystem_error: filesystem_error -> string
 
 module Make (B: V1.BLOCK
   with type 'a io = 'a Lwt.t
-  and type page_aligned_buffer = Cstruct.t)(M: V1.IO_PAGE
-  with type buf = Cstruct.t): (V1.FS
+  and type page_aligned_buffer = Cstruct.t)(M: S.IO_PAGE): (V1.FS
   with type id = B.t
   and type 'a io = 'a Lwt.t
   and type block_device_error = B.error

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -18,7 +18,12 @@ module type BLOCK_DEVICE = V1.BLOCK
   with type page_aligned_buffer = Cstruct.t
    and type 'a io = 'a Lwt.t
 
-module type IO_PAGE = V1.IO_PAGE
+module type IO_PAGE = sig
+  val get_buf : ?n:int -> unit -> Cstruct.t
+  (** [get_buf ~n ()] allocates and returns a memory block of [n] pages,
+      represented as a {!Cstruct.t}. If there is not enough memory,
+      an [Out_of_memory] exception is raised. *)
+end
 
 module type FS = V1.FS
 with type page_aligned_buffer = Cstruct.t


### PR DESCRIPTION
There's no need to ask for the whole interface when we only need one function. This should allow removing IO_PAGE from mirage-types.

See: https://github.com/mirage/mirage/pull/356