### PR TITLE
Update for new DEVICE API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* MemoryIO.connect now takes an FS.t, not an FS.id.
+
 0.10.2 (31-1-2015)
 * Fixed destroy, which previously would overwrite the entry with
   uninitialised data, which might not set the deleted flag.

--- a/lib/KV_RO.ml
+++ b/lib/KV_RO.ml
@@ -23,21 +23,17 @@ module Make(FS: FS with
 
   type t = FS.t
   type +'a io = 'a Lwt.t
-  type id = FS.id
+  type id = FS.t
   type page_aligned_buffer = FS.page_aligned_buffer
 
   type error = Unknown_key of string
 
-  let connect id =
-    FS.connect id
-    >>= function
-    | `Error _ -> return (`Error (Unknown_key "connect"))
-    | `Ok t -> return (`Ok t)
+  let connect t = return (`Ok t)
 
   let disconnect id =
     FS.disconnect id
 
-  let id t = FS.id t
+  let id t = t
 
   let read t name off len =
     FS.read t name off len

--- a/lib/fs.ml
+++ b/lib/fs.ml
@@ -57,12 +57,7 @@ let string_of_filesystem_error = function
 
 module Make (B: BLOCK_DEVICE
   with type 'a io = 'a Lwt.t
-  and type page_aligned_buffer = Cstruct.t)(M: IO_PAGE): (FS
-  with type id = B.t
-  and type 'a io = 'a Lwt.t
-  and type block_device_error = B.error
-  and type page_aligned_buffer = Cstruct.t
-) = struct
+  and type page_aligned_buffer = Cstruct.t)(M: IO_PAGE) = struct
   type t = {
     device: B.t;
     mutable fs: fs option; (* a filesystem is either formatted or not *)

--- a/lib/fs.mli
+++ b/lib/fs.mli
@@ -34,9 +34,11 @@ val string_of_filesystem_error: filesystem_error -> string
 
 module Make (B: V1.BLOCK
   with type 'a io = 'a Lwt.t
-  and type page_aligned_buffer = Cstruct.t)(M: S.IO_PAGE): (V1.FS
-  with type id = B.t
-  and type 'a io = 'a Lwt.t
-  and type block_device_error = B.error
-  and type page_aligned_buffer = Cstruct.t
-)
+  and type page_aligned_buffer = Cstruct.t)(M: S.IO_PAGE) : sig
+  include V1.FS
+    with type id = B.t
+    and type 'a io = 'a Lwt.t
+    and type block_device_error = B.error
+    and type page_aligned_buffer = Cstruct.t
+  val connect : B.t -> [`Ok of t | `Error of error] io
+end

--- a/lib/memoryIO.mli
+++ b/lib/memoryIO.mli
@@ -18,3 +18,5 @@ include S.BLOCK_DEVICE
   with type 'a io = 'a Lwt.t
    and type page_aligned_buffer = Cstruct.t
    and type id = string
+
+val connect : string -> [`Ok of t | `Error of error] io


### PR DESCRIPTION
- Add explicit `connect` function to interfaces.
- `KV_RO`'s connect now takes an `FS.t`, not an `FS.id`.

See: https://github.com/mirage/mirage/pull/350