### PR TITLE
kv_ro will be a KV_RO with 'a io = 'a Lwt.io

### DIFF
--- a/lib/KV_RO.mli
+++ b/lib/KV_RO.mli
@@ -16,7 +16,10 @@
 
 open V1
 
-module Make(FS : FS with type 'a io = 'a Lwt.t) : sig
+module Make(FS : FS with type 'a io = 'a Lwt.t and type page_aligned_buffer = Cstruct.t) : sig
   include KV_RO
+    with type 'a io = 'a Lwt.t
+     and type page_aligned_buffer = Cstruct.t
+
   val connect : FS.t -> t FS.io
 end


### PR DESCRIPTION
https://travis-ci.org/mirage/mirage-www/jobs/164560811 said:
       Type declarations do not match:
         type 'a io = 'a Fat.KV_RO.Make(Fat1).io
       is not included in
         type 'a io = 'a Lwt.t