### PR TITLE
Install the `fat` command-line tool

### DIFF
--- a/bin/jbuild
+++ b/bin/jbuild
@@ -4,3 +4,8 @@
  ((names (main))
   (libraries  (fat-filesystem mirage-block-unix cmdliner mirage-fs-lwt io-page-unix)
 )))
+
+(install
+ ((section bin)
+  (package fat-filesystem)
+  (files ((main.exe as fat)))))


### PR DESCRIPTION
This was missed in the jbuilder conversation.

Needed by https://github.com/mirage/mirage-www/pull/558

Signed-off-by: David Scott <dave@recoil.org>