### PR TITLE
Use Re.Str instead of deprecated Re_str

### DIFF
--- a/fat-filesystem.opam
+++ b/fat-filesystem.opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-block-unix" {>= "2.5.0"}
   "io-page-unix" {>= "2.0.0"}
-  "re"
+  "re" {>= "1.7.2"}
   "cmdliner"
   "astring"
   "alcotest" {test}

--- a/src/fat_name.ml
+++ b/src/fat_name.ml
@@ -118,8 +118,8 @@ let legal_dos_string x =
     true
   with Not_found -> false
 
-let dot = Re_str.regexp_string "."
-let is_legal_dos_name filename = match Re_str.split dot filename with
+let dot = Re.Str.regexp_string "."
+let is_legal_dos_name filename = match Re.Str.split dot filename with
   | [ one ] -> String.length one <= 8 && (legal_dos_string one)
   | [ one; two ] -> String.length one <= 8
                     && (String.length two <= 3)
@@ -138,7 +138,7 @@ let uppercase = Astring.String.Ascii.uppercase
 
 let dos_name_of_filename filename =
   if is_legal_dos_name filename
-  then match Re_str.split dot filename with
+  then match Re.Str.split dot filename with
     | [ one ] -> add_padding ' ' 8 one, "   "
     | [ one; two ] -> add_padding ' ' 8 one, add_padding ' ' 3 two
     | _ -> assert false (* implied by is_legal_dos_name *)

--- a/src/fat_path.ml
+++ b/src/fat_path.ml
@@ -23,9 +23,9 @@ let filename = List.hd
 
 let to_string p = "/" ^ (String.concat "/" (to_string_list p))
 
-let slash = Re_str.regexp_string "/"
+let slash = Re.Str.regexp_string "/"
 
-let of_string s = if s = "/" || s = "" then [] else of_string_list (Re_str.split slash s)
+let of_string s = if s = "/" || s = "" then [] else of_string_list (Re.Str.split slash s)
 
 let concat path x = x :: path
 


### PR DESCRIPTION
Needed to fix compilation issue: "`Re_str` is deprecated".

`Re_*` modules were deprecated on 1.7.2 https://github.com/ocaml/ocaml-re/releases/tag/1.7.2, so `fat-filesystem.opam` should be updated accordingly to point to it. I guess that means that the version of `fat-filesystem` should also be upgraded? don't know how to handle that change.

```
opam@46523ff82eb7:~/ocaml-fat$ make
...
File "src/fat_name.ml", line 121, characters 10-30:
Warning 3: deprecated: module Re_str
Use Re.Str
File "src/fat_name.ml", line 122, characters 39-51:
Warning 3: deprecated: module Re_str
Use Re.Str
File "src/fat_name.ml", line 141, characters 13-25:
Warning 3: deprecated: module Re_str
Use Re.Str
File "src/fat_name.ml", line 1:
Error: Some fatal warnings were triggered (3 occurrences)
Makefile:5: recipe for target 'build' failed
make: *** [build] Error 1
```