### PR TITLE
fat bin using the block --buffered arg for connect

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -17,7 +17,7 @@ open Lwt.Infix
 open Result
 open Mirage_fs
 
-module Filesystem = Fat_fs.Make(Block)
+module Filesystem = Fat.FS(Block)
 open Common
 
 (* Default policy when we hit a block- or fs-level error which we don't
@@ -87,11 +87,6 @@ let run t =
   with
   | Failure x -> `Error(false, x)
 
-let buffered common filename =
-  if common.unbuffered
-  then filename
-  else "buffered:" ^ filename
-
 let create common filename size =
   let size =
     let sz = parse_size size in
@@ -113,7 +108,7 @@ let create common filename size =
     done;
     Block.really_write fd sector >>= fun () ->
     Lwt_unix.close fd >>= fun () ->
-    Block.connect (buffered common filename) >>= fun device ->
+    Block.connect ~buffered:(not common.unbuffered) filename >>= fun device ->
     Filesystem.format device size >>*= fun _fs ->
     if common.verb then Printf.printf "Filesystem of size %Ld created\n%!" size;
     Lwt.return ()
@@ -125,7 +120,7 @@ let add common filename files =
   let files = List.tl files in
   Printf.fprintf stderr "add %s <- [ %s ]\n%!" filename (String.concat "; " files);
   let t =
-    Block.connect (buffered common filename) >>= fun device ->
+    Block.connect ~buffered:(not common.unbuffered) filename >>= fun device ->
     if common.verb then Printf.printf "Opened %s\n%!" filename;
     Filesystem.connect device >>= fun fs ->
     let rec copyin outside_path inside_path file =
@@ -160,7 +155,7 @@ let add common filename files =
 
 let list common filename =
   let t =
-    Block.connect (buffered common filename) >>= fun device ->
+    Block.connect ~buffered:(not common.unbuffered) filename >>= fun device ->
     Filesystem.connect device >>= fun fs ->
     let rec loop curdir =
       Filesystem.listdir fs curdir >>*= fun children ->
@@ -182,7 +177,7 @@ let list common filename =
 
 let cat common filename path =
   let t =
-    Block.connect (buffered common filename) >>= fun device ->
+    Block.connect ~buffered:(not common.unbuffered) filename >>= fun device ->
     Filesystem.connect device >>= fun fs ->
     let rec loop offset =
       Filesystem.read fs path offset 1024 >>*= fun bufs ->


### PR DESCRIPTION
mirage-block-unix.2.5.0 has an arg to specify the use of unbuffered IO (`O_DIRECT` flag on open) on `connect`, an optional `--buffered`. This change uses that instead of the current appending of "buffered:" in front of the file name. This fixes #64.

Also, was looking at mirage-block-solo5, and it doesn't implement the `--buffered` arg. The fat bin tool uses block-unix, so that's good, but we should really implement that arg in solo5.

Test:
```
[ocaml-fat]$ strace ./_build/install/default/bin/fat list --unbuffered test/fat.dat 2>&1 | grep open
...
open("test/fat.dat", O_RDWR|O_DIRECT)   = 4

[ocaml-fat]$ strace ./_build/install/default/bin/fat list test/fat.dat 2>&1 | grep open
...
open("test/fat.dat", O_RDWR)            = 4
```